### PR TITLE
[TASK] Define extension key in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,6 @@
       "CPSIT\\GeoLocationService\\": "Classes/"
     }
   },
-  "replace": {
-    "typo3-ter/geo-location-service": "self.version"
-  },
   "extra": {
     "typo3/cms": {
       "extension-key": "geo_location_service"

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,10 @@
   "replace": {
     "geo_location_service": "self.version",
     "typo3-ter/geo-location-service": "self.version"
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "geo_location_service"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     }
   },
   "replace": {
-    "geo_location_service": "self.version",
     "typo3-ter/geo-location-service": "self.version"
   },
   "extra": {


### PR DESCRIPTION
This PR adds the `extension-key` configuration as described in the [official TYPO3 documentation](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra). Additionally, the outdated `replace` config is removed since it's [no longer evaluated](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/ComposerJson/Index.html#properties-no-longer-used).